### PR TITLE
Update camera noise formula

### DIFF
--- a/irg_gazebo_plugins/materials/scripts/IRGCameraSim.frag
+++ b/irg_gazebo_plugins/materials/scripts/IRGCameraSim.frag
@@ -90,7 +90,7 @@ float rand(vec2 co)
     return r;
 }
 
-vec4 gaussrand(float I, vec2 co, float num_bits)
+vec4 gaussrand(float I, vec2 co, float integer_limit)
 {
   // Box-Muller method for sampling from the normal distribution
   // http://en.wikipedia.org/wiki/Normal_distribution#Generating_values_from_normal_distribution
@@ -114,21 +114,21 @@ vec4 gaussrand(float I, vec2 co, float num_bits)
   //Z = Z * stddev + mean;
 
   // Shot noise standard deviation is some constant times the square root of
-  // pixel intensity (intensity in units of bits).
-  float shot_noise_std_dev_squared = shot_noise_coeff * shot_noise_coeff * I * num_bits;
+  // integer pixel intensity.
+  float shot_noise_std_dev_squared = shot_noise_coeff * shot_noise_coeff * I * integer_limit;
   // Because standard deviations here are measured in bits. The final stddev is
   // divided by the total number of bits to put it in the range {0, 1}
-  float stddev = sqrt(read_noise_std_dev * read_noise_std_dev + shot_noise_std_dev_squared) / num_bits;
+  float stddev = sqrt(read_noise_std_dev * read_noise_std_dev + shot_noise_std_dev_squared) / integer_limit;
   Z = Z * stddev;
 
   // Return it as a vec4, to be added to the input ("true") color.
   return vec4(Z, Z, Z, 0.0);
 }
 
-vec3 downsample(vec3 color, float num_bits)
+vec3 downsample(vec3 color, float integer_limit)
 {
-  vec3 num_bits_vec = vec3(num_bits);
-  return floor(color * num_bits_vec) / num_bits_vec;
+  vec3 integer_limit_vec = vec3(integer_limit);
+  return floor(color * integer_limit_vec) / integer_limit_vec;
 
   // If you are downsampling to, for example, 5 bits and rendering the final
   // image to an 8-bit framebuffer or texture, you would expect the least
@@ -144,7 +144,7 @@ vec3 downsample(vec3 color, float num_bits)
 
   // An alternative way to downsample the texture would be:
   //
-  // return color * (num_bits / render_target_num_bits);
+  // return color * (integer_limit / render_target_integer_limit);
   //
   // This would cause a smaller range of the final image's possible values to
   // be used. The resulting image would look dark to a human viewer but might
@@ -161,12 +161,13 @@ void main()
   // convert light power to sensor signal
   color.rgb *= vec3(energy_conversion);
 
-  // number of bits per pixel output by camera
-  float num_bits = pow(2.0, adc_bits);
+  // Number of possible values in the final image encoded as integers, or the
+  // analog-to-digital limit.
+  float integer_limit = pow(2.0, adc_bits);
 
   // luminance noise
   float gray = dot(color.rgb, vec3(0.299, 0.587, 0.114));
-  color.rgb += vec3(gaussrand(gray, gl_TexCoord[0].xy, num_bits));
+  color.rgb += vec3(gaussrand(gray, gl_TexCoord[0].xy, integer_limit));
 
   // sensor gain
   color.rgb *= vec3(gain);
@@ -179,6 +180,6 @@ void main()
   color.rgb = pow(color.rgb, vec3(gamma));
 
   // downsample to simulate camera's analog-to-digital converter
-  gl_FragColor = vec4(downsample(color.rgb, num_bits), color.a);
+  gl_FragColor = vec4(downsample(color.rgb, integer_limit), color.a);
 }
 

--- a/irg_gazebo_plugins/materials/scripts/IRGCameraSim.frag
+++ b/irg_gazebo_plugins/materials/scripts/IRGCameraSim.frag
@@ -61,7 +61,7 @@ uniform vec3 offsets;
 //uniform float stddev;
 
 // Read noise standard deviation (in integer pixel value where pixel values are
-// in the range {0, 2^adc_bits - 1} )
+// in the interval [0, 2^adc_bits - 1] )
 uniform float read_noise_std_dev;
 
 // Shot noise coefficient (unitless)
@@ -117,8 +117,8 @@ vec4 gaussrand(float I, vec2 co, float integer_limit)
   // Shot noise standard deviation is some constant times the square root of
   // integer pixel intensity.
   float shot_noise_std_dev_squared = shot_noise_coeff * shot_noise_coeff * I * integer_limit;
-  // Because standard deviations here are measured in integers. The final stddev
-  // is divided by the integer limit to put it in the floating point range {0.0, 1.0}
+  // Because standard deviations here are measured in integers, the final stddev
+  // is divided by the integer limit to put it in the floating point interval [0.0, 1.0]
   float stddev = sqrt(read_noise_std_dev * read_noise_std_dev + shot_noise_std_dev_squared) / integer_limit;
   Z = Z * stddev;
 

--- a/irg_gazebo_plugins/materials/scripts/IRGCameraSim.frag
+++ b/irg_gazebo_plugins/materials/scripts/IRGCameraSim.frag
@@ -116,8 +116,8 @@ vec4 gaussrand(float I, vec2 co, float integer_limit)
   // Shot noise standard deviation is some constant times the square root of
   // integer pixel intensity.
   float shot_noise_std_dev_squared = shot_noise_coeff * shot_noise_coeff * I * integer_limit;
-  // Because standard deviations here are measured in bits. The final stddev is
-  // divided by the total number of bits to put it in the range {0, 1}
+  // Because standard deviations here are measured in integers. The final stddev
+  // is divided by the integer limit to put it in the floating point range {0.0, 1.0}
   float stddev = sqrt(read_noise_std_dev * read_noise_std_dev + shot_noise_std_dev_squared) / integer_limit;
   Z = Z * stddev;
 

--- a/irg_gazebo_plugins/materials/scripts/IRGCameraSim.frag
+++ b/irg_gazebo_plugins/materials/scripts/IRGCameraSim.frag
@@ -60,7 +60,8 @@ uniform vec3 offsets;
 // Standard deviation of the Gaussian distribution that we want to sample from.
 //uniform float stddev;
 
-// Read noise standard deviation (in bits)
+// Read noise standard deviation (in integer pixel value where pixel values are
+// in the range {0, 2^adc_bits - 1} )
 uniform float read_noise_std_dev;
 
 // Shot noise coefficient (unitless)

--- a/irg_gazebo_plugins/materials/scripts/irg_gazebo_plugins.material
+++ b/irg_gazebo_plugins/materials/scripts/irg_gazebo_plugins.material
@@ -24,8 +24,8 @@ fragment_program IRGCameraSimFS glsl
     param_named exposure float 1.0
     param_named gamma float 1.0
     param_named energy_conversion float 1.0
-    param_named read_noise float 0.64
-    param_named shot_noise float 0.09
+    param_named read_noise_std_dev float 0.8
+    param_named shot_noise_coeff float 0.3
     param_named offsets float3 0.0 0.0 0.0
     param_named gain float 1.0
     param_named adc_bits float 12.0

--- a/irg_gazebo_plugins/src/IRGCameraSimPlugins/CameraCompositorListener.cpp
+++ b/irg_gazebo_plugins/src/IRGCameraSimPlugins/CameraCompositorListener.cpp
@@ -25,8 +25,8 @@ CameraCompositorListener::CameraCompositorListener(sdf::ElementPtr sdf)
   // Declare shader param names and default values
   initParam("exposure", 1.0);
   initParam("energy_conversion", 1.0);
-  initParam("read_noise", 0.64);
-  initParam("shot_noise", 0.09);
+  initParam("read_noise_std_dev", 0.8);
+  initParam("shot_noise_coeff", 0.3);
   initParam("gain", 1.0);
   initParam("gamma", 1.0);
   initParam("adc_bits", 12.0);

--- a/irg_gazebo_plugins/src/IRGCameraSimPlugins/README.md
+++ b/irg_gazebo_plugins/src/IRGCameraSimPlugins/README.md
@@ -62,8 +62,8 @@ settled on a VisualPlugin instead.
 The plugins can be initialized with user-defined values using the following parameters:
  - `<topic_uid>` - Changes topic from `/gazebo/plugins/camera_sim/<topic>` to `/gazebo/plugins/camera_sim/<topic_uid>/<topic>`.
  - `<exposure>` - Exposure time (seconds). Default = 1.0
- - `<energy_conversion>` - Pixel value in range {0.0, 1.0} per lux-second. A conversion factor from luminous energy to normalized sensor output. Default = 1.0
- - `<read_noise_std_dev>` - Read noise standard deviation (in integer pixel value where pixel values are in the range {0, 2<sup>adc_bits</sup> - 1}). Default = 0.8
+ - `<energy_conversion>` - Pixel value per lux-second in the interval [0.0, 1.0]. A conversion factor from luminous energy to normalized sensor output. Default = 1.0
+ - `<read_noise_std_dev>` - Read noise standard deviation (in integer pixel value where pixel values are in the interval [0, 2<sup>adc_bits</sup> - 1] ). Default = 0.8
  - `<shot_noise_coeff>` - Shot noise coefficient (unitless). Default = 0.3
  - `<gain>` - Simulate sensor gain by multiplying 16-bit version of exposed image by this value. Default = 1.0
  - `<gamma>` - Curve final image by this power. Default = 1.0
@@ -137,11 +137,11 @@ shot_noise_std_dev = shot_noise_coeff ^ 2 * I
 std_dev = sqrt(read_noise_std_dev ^ 2 + shot_noise_std_dev ^ 2)
 ```
 
-where I is the image intensity at a given pixel in the range
-{0, 2<sup>adc_bits</sup> - 1}. `std_dev` is the standard deviation used to
+where I is the image intensity at a given pixel in the interval
+[0, 2<sup>adc_bits</sup> - 1]. `std_dev` is the standard deviation used to
 choose a random Gaussian offset for that pixel. Note that the inputs
 `read_noise_std_dev` and `shot_noise_coeff` affect the level of noise to apply
-to each pixel in the same image intensity range, and so they are coupled with
+to each pixel in the same image intensity interval, and so they are coupled with
 your choice of `adc_bits`. Decreasing `adc_bits` will increase the visual impact
 of noise.
 
@@ -155,14 +155,14 @@ depth greater than or equal to that of the adc_bits you set for this plugin. If
 your image format has a smaller bit depth, you will lose desired image detail.
 
 #### Writing final image to texture
-Internally, GLSL shaders keep color values in the range {0.0, 1.0}. When our
-simulated ADC converts to, say, 12-bits, it keeps the color in the range {0.0, 1.0}
-but it uses 4096 distinct values in that range. When this result is written to a
-16-bit render target, it uses 4096 distinct values spread throughout that range
-of 65536 values.
+Internally, GLSL shaders keep color values in the interval [0.0, 1.0]. When our
+simulated ADC converts to, say, 12-bits, it keeps the color in the interval
+[0.0, 1.0] but it uses 4096 distinct values in that interval. When this result
+is written to a 16-bit render target, it uses 4096 distinct values spread
+throughout that interval of 65536 values.
 
-An alternative method would be to write to the *lowest* 4096 values in that range
-of 65536 values. This would require modifying the shader and its inputs.
+An alternative method would be to write to the *lowest* 4096 values in that
+interval of 65536 values. This would require modifying the shader and its inputs.
 
 Both versions of this final image would contain the same amount of information.
 We currently don't know if computer vision algorithms would behave the same or

--- a/irg_gazebo_plugins/src/IRGCameraSimPlugins/README.md
+++ b/irg_gazebo_plugins/src/IRGCameraSimPlugins/README.md
@@ -63,7 +63,7 @@ The plugins can be initialized with user-defined values using the following para
  - `<topic_uid>` - Changes topic from `/gazebo/plugins/camera_sim/<topic>` to `/gazebo/plugins/camera_sim/<topic_uid>/<topic>`.
  - `<exposure>` - Exposure time (seconds). Default = 1.0
  - `<energy_conversion>` - Pixel value in range {0.0, 1.0} per lux-second. A conversion factor from luminous energy to normalized sensor output. Default = 1.0
- - `<read_noise_std_dev>` - Read noise standard deviation (in bits). Default = 0.8
+ - `<read_noise_std_dev>` - Read noise standard deviation (in integer pixel value where pixel values are in the range {0, 2<sup>adc_bits</sup> - 1}). Default = 0.8
  - `<shot_noise_coeff>` - Shot noise coefficient (unitless). Default = 0.3
  - `<gain>` - Simulate sensor gain by multiplying 16-bit version of exposed image by this value. Default = 1.0
  - `<gamma>` - Curve final image by this power. Default = 1.0
@@ -138,11 +138,12 @@ std_dev = sqrt(read_noise_std_dev ^ 2 + shot_noise_std_dev ^ 2)
 ```
 
 where I is the image intensity at a given pixel in the range
-{0, 2<sup>adc_bits</sup>}. `std_dev` is the standard deviation used to choose a
-random Gaussian offset for that pixel. Note that the inputs `read_noise_std_dev`
-and `shot_noise_coeff` affect the number of bits of noise to apply to each
-pixel, and so they are coupled with your choice of `adc_bits`. Decreasing
-`adc_bits` will increase the visual impact of noise.
+{0, 2<sup>adc_bits</sup> - 1}. `std_dev` is the standard deviation used to
+choose a random Gaussian offset for that pixel. Note that the inputs
+`read_noise_std_dev` and `shot_noise_coeff` affect the level of noise to apply
+to each pixel in the same image intensity range, and so they are coupled with
+your choice of `adc_bits`. Decreasing `adc_bits` will increase the visual impact
+of noise.
 
 ### Analog-to-digital converter
 The voltages coming out of a digital camera's sensor must be converted to a


### PR DESCRIPTION
The main problem was there was a hardcoded value that assumed camera images would always be 12-bit images. That's fixed. Also, `read_noise` was changed to `read_noise_std_dev` and `shot_noise` was changed to `shot_noise_coeff`. `read_noise` was like `read_noise_std_dev` squared, which was confusing to work with. `shot_noise` was similarly confusing. Defaults for the new params were updated such that images should look exactly as they did before.

Sibling PR: https://github.com/nasa/ow_europa/pull/16