### PR TITLE
Removed bad error message

### DIFF
--- a/irg_gazebo_plugins/src/IRGCameraSimPlugins/CameraSimVisualPlugin.cpp
+++ b/irg_gazebo_plugins/src/IRGCameraSimPlugins/CameraSimVisualPlugin.cpp
@@ -38,12 +38,17 @@ void CameraSimVisualPlugin::Load(rendering::VisualPtr visual, sdf::ElementPtr sd
     return;
   }
 
+  // This plugin is intended only for gzclient's UserCamera and not for gzserver
+  if (scene->IsServer())
+  {
+    return;
+  }
+
   // Should this handle multiple user cameras? In what cases are there more than one?
   m_camera = scene->GetUserCamera(0);
   if (m_camera == nullptr)
   {
-    // No error is printed here. Finding a camera is expected behavior for a
-    // VisualPlugin running on gzclient but not on gzserver.
+    gzerr << "Camera is null. CameraSimVisualPlugin won't load." << std::endl;
     return;
   }
 

--- a/irg_gazebo_plugins/src/IRGCameraSimPlugins/CameraSimVisualPlugin.cpp
+++ b/irg_gazebo_plugins/src/IRGCameraSimPlugins/CameraSimVisualPlugin.cpp
@@ -42,7 +42,8 @@ void CameraSimVisualPlugin::Load(rendering::VisualPtr visual, sdf::ElementPtr sd
   m_camera = scene->GetUserCamera(0);
   if (m_camera == nullptr)
   {
-    gzerr << "Camera is null. CameraSimVisualPlugin won't load." << std::endl;
+    // No error is printed here. Finding a camera is expected behavior for a
+    // VisualPlugin running on gzclient but not on gzserver.
     return;
   }
 


### PR DESCRIPTION
`[Err] [CameraSimVisualPlugin.cpp:45] Camera is null. CameraSimVisualPlugin won't load.` should not print in the console using this code change.