### PR TITLE
Updated all CMakesLists.txt files to required cmake v3.0.2

### DIFF
--- a/irg_gazebo_plugins/CMakeLists.txt
+++ b/irg_gazebo_plugins/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(irg_gazebo_plugins)
 
 add_compile_options(-Wno-register)

--- a/irg_planetary_ephemeris/CMakeLists.txt
+++ b/irg_planetary_ephemeris/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(irg_planetary_ephemeris)
 
 ## Find catkin macros and libraries

--- a/irg_spice/CMakeLists.txt
+++ b/irg_spice/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(irg_spice)
 
 ## Find catkin macros and libraries

--- a/irg_tools/CMakeLists.txt
+++ b/irg_tools/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(irg_tools)
 
 ## Add support for C++11, supported in ROS Kinetic and newer


### PR DESCRIPTION
## Linked Issues:
| EPIC ⚡ | N/A |
| :----------- | :----------- |
| Jira Ticket 🎟️ | [OCEANWATER-981](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-981) |
| Github :octocat:  | # |

## Summary of Changes
* Updated all CMakesLists.txt following [this ROS Noetic migration step](http://wiki.ros.org/noetic/Migration#Increase_required_CMake_version_to_avoid_author_warning), which has eliminated the following cmake warning.
```
Warnings   << ow_plexil:check /usr/local/home/tstucky/ow/workspace/logs/ow_plexil/build.check.002.log                                          
CMake Warning (dev) at CMakeLists.txt:2 (project): 
 Policy CMP0048 is not set: project() command manages VERSION variables. 
 Run "cmake --help-policy CMP0048" for policy details.  Use the cmake_policy 
 command to set the policy and suppress this warning.
 The following variable(s) would be set to empty:
   CMAKE_PROJECT_VERSION 
   CMAKE_PROJECT_VERSION_MAJOR 
   CMAKE_PROJECT_VERSION_MINOR 
   CMAKE_PROJECT_VERSION_PATCH 
This warning is for project developers.  Use -Wno-dev to suppress it.
```

## Test
See [ow_simulator #247](https://github.com/nasa/ow_simulator/pull/247) for test instructions.
