### PR TITLE
Darkened planets by factor of pi.

### DIFF
--- a/irg_planetary_ephemeris/models/irg_earth/materials/scripts/irg_planet.frag
+++ b/irg_planetary_ephemeris/models/irg_earth/materials/scripts/irg_planet.frag
@@ -12,11 +12,13 @@ in vec2 uv;
 
 out vec4 outputCol;
 
+const float PI = 3.14159265358979;
+
 void main()
 {
   vec3 color = texture2D(diffuseMap, uv).rgb * albedoScale;
 
-  color *= sunIntensity * max(dot(normalize(vsNormal), vsVecToSun), 0.0);
+  color *= sunIntensity * max(dot(normalize(vsNormal), vsVecToSun), 0.0) / PI;
 
   outputCol = vec4(color, 1.0);
 }


### PR DESCRIPTION
Planets should have been darkened by factor of pi. This is the correct way to implement Lambertian shading. We should have darkened planets along with terrain when we did this PR: https://github.com/nasa/ow_simulator/pull/376

It would be more realistic to render planets using a Hapke or Oren-Nayar shading model, but those models require extra parameters that can be difficult to estimate properly. Also, this would be a very small visual change that most people would never notice.