### PR TITLE
Suppressed cacheParams messages in sim output

### DIFF
--- a/irg_gazebo_plugins/src/IRGGlobalShaderParamPlugin/GlobalShaderParamPlugin.cpp
+++ b/irg_gazebo_plugins/src/IRGGlobalShaderParamPlugin/GlobalShaderParamPlugin.cpp
@@ -226,7 +226,7 @@ void GlobalShaderParamPlugin::cacheParams(int8_t shaderType , const std::string&
       }
     }
   }
-  gzmsg << "GlobalShaderParamPlugin::cacheParams(" << paramName.c_str() << ", " << paramsList.size() << ")\n";
+  gzlog << "GlobalShaderParamPlugin::cacheParams(" << paramName.c_str() << ", " << paramsList.size() << ")\n";
 }
 
 


### PR DESCRIPTION
@mogumbo You can skip the test, we're just seeking your approval on this small change. 

## Summary of Changes
cacheParams message, which is called each time a model spawns into the simulation, is now only logged and is not printed to the simulation terminal. 

## Test
@kmdalal please run the following test
1. Lauch atacama_y1a
2. In a second terminal view the gazebo server log `tail -F ~/.gazebo/server-#####/default.log`
3. In a third terminal command a grind `task_grind.py`
4. Then command a dig `task_scoop_linear.py`
5. In the second terminal you should still see the cacheParams message printed each time a regolith particle is spawned.
```
(1712871540 571133442) GlobalShaderParamPlugin::cacheParams(sunVisibility, 29)
```
6. In the simulation output you should not see anything printed while particles spawn. 

